### PR TITLE
fix: Fixes the implicit OAuth flow not waiting for user to authenticate

### DIFF
--- a/plugins/auth-oauth2/src/grants/implicit.ts
+++ b/plugins/auth-oauth2/src/grants/implicit.ts
@@ -31,7 +31,7 @@ export function getImplicit(
     }
 
     const authorizationUrl = new URL(`${authorizationUrlRaw ?? ''}`);
-    authorizationUrl.searchParams.set('response_type', 'code');
+    authorizationUrl.searchParams.set('response_type', 'token');
     authorizationUrl.searchParams.set('client_id', clientId);
     if (redirectUri) authorizationUrl.searchParams.set('redirect_uri', redirectUri);
     if (scope) authorizationUrl.searchParams.set('scope', scope);
@@ -42,25 +42,33 @@ export function getImplicit(
     }
 
     const authorizationUrlStr = authorizationUrl.toString();
+    let foundAccessToken = false;
     let { close } = await ctx.window.openUrl({
       url: authorizationUrlStr,
       label: 'oauth-authorization-url',
+      async onClose() {
+        if (!foundAccessToken) {
+          reject(new Error('Authorization window closed'));
+        }
+      },
       async onNavigate({ url: urlStr }) {
         const url = new URL(urlStr);
         if (url.searchParams.has('error')) {
           return reject(Error(`Failed to authorize: ${url.searchParams.get('error')}`));
         }
 
+        const hash = url.hash.slice(1);
+        const params = new URLSearchParams(hash);
+
+        const accessToken = params.get('access_token');
+        if (!accessToken) {
+          return;
+        }
+        foundAccessToken = true;
+
         // Close the window here, because we don't need it anymore
         close();
 
-        const hash = url.hash.slice(1);
-        const params = new URLSearchParams(hash);
-        const idToken = params.get('id_token');
-        if (idToken) {
-          params.set('access_token', idToken);
-          params.delete('id_token');
-        }
         const response = Object.fromEntries(params) as unknown as AccessTokenRawResponse;
         try {
           resolve(await storeToken(ctx, contextId, response));


### PR DESCRIPTION
When using the implicit flow for OAuth authentication, the authentication window would close immediately and an error toast would appear saying no token was found in the response.

Comparing the implicit flow implementation with the authorization code one, I realized this was due to the implicit flow implementation not considering that the first webview navigation would be to the authentication page itself, rather than the authentication response.

I believe this should fix [this issue](https://feedback.yaak.app/p/oauth-implicit-mode-login-window-just-closes) from a couple months ago.